### PR TITLE
feat: Add admin order entry form

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -12,6 +12,23 @@
     </header>
 
     <main>
+        <section id="order-now">
+            <h2>Place a New Order</h2>
+            <form id="new-order-form">
+                <div class="input-group">
+                    <label for="customer-name">Customer Name</label>
+                    <input type="text" id="customer-name" name="customer-name" required>
+                </div>
+                <fieldset>
+                    <legend>Menu Items</legend>
+                    <div id="menu-items-container">
+                        <!-- Menu items will be injected here by JS -->
+                    </div>
+                </fieldset>
+                <button type="submit">Place Order</button>
+            </form>
+        </section>
+
         <section id="orders">
             <h2>Current Orders</h2>
             <table id="orders-table">

--- a/css/style.css
+++ b/css/style.css
@@ -175,3 +175,21 @@ section {
 #orders-table tbody tr:nth-child(even) {
     background-color: #f9f9f9;
 }
+
+#new-order-form fieldset {
+    border: 1px solid #ddd;
+    padding: 1rem;
+    margin-bottom: 1rem;
+}
+
+#menu-items-container {
+    max-height: 200px;
+    overflow-y: auto;
+    border: 1px solid #eee;
+    padding: 0.5rem;
+}
+
+#menu-items-container label {
+    display: block;
+    margin-bottom: 0.5rem;
+}

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,21 +1,87 @@
 document.addEventListener('DOMContentLoaded', () => {
     const ordersTableBody = document.querySelector('#orders-table tbody');
+    const menuItemsContainer = document.getElementById('menu-items-container');
+    const newOrderForm = document.getElementById('new-order-form');
 
-    if (orders && ordersTableBody) {
-        orders.forEach(order => {
-            const row = document.createElement('tr');
+    // --- 1. Populate the "Order Now" form with menu items ---
+    if (menu && menuItemsContainer) {
+        for (const category in menu) {
+            menu[category].forEach(item => {
+                const checkbox = document.createElement('input');
+                checkbox.type = 'checkbox';
+                checkbox.id = `item-${item.id}`;
+                checkbox.name = 'menu-items';
+                checkbox.value = item.id;
 
-            const itemsFormatted = order.items.map(item => item.name).join(', ');
+                const label = document.createElement('label');
+                label.htmlFor = `item-${item.id}`;
+                label.textContent = `${item.name} - $${item.price.toFixed(2)}`;
 
-            row.innerHTML = `
-                <td>${order.orderId}</td>
-                <td>${order.customerName}</td>
-                <td>${itemsFormatted}</td>
-                <td>${new Date(order.deliveryTime).toLocaleString()}</td>
-                <td>$${order.totalPrice.toFixed(2)}</td>
-            `;
+                const container = document.createElement('div');
+                container.appendChild(checkbox);
+                container.appendChild(label);
+                menuItemsContainer.appendChild(container);
+            });
+        }
+    }
 
-            ordersTableBody.appendChild(row);
+    // --- 2. Function to render the orders table ---
+    function renderOrdersTable() {
+        ordersTableBody.innerHTML = ''; // Clear existing table rows
+        if (orders && ordersTableBody) {
+            orders.forEach(order => {
+                const row = document.createElement('tr');
+                const itemsFormatted = order.items.map(item => item.name).join(', ');
+                row.innerHTML = `
+                    <td>${order.orderId}</td>
+                    <td>${order.customerName}</td>
+                    <td>${itemsFormatted}</td>
+                    <td>${new Date(order.deliveryTime).toLocaleString()}</td>
+                    <td>$${order.totalPrice.toFixed(2)}</td>
+                `;
+                ordersTableBody.appendChild(row);
+            });
+        }
+    }
+
+    // --- 3. Handle new order form submission ---
+    if (newOrderForm) {
+        newOrderForm.addEventListener('submit', (e) => {
+            e.preventDefault();
+
+            const customerNameInput = document.getElementById('customer-name');
+            const customerName = customerNameInput.value;
+            const selectedCheckboxes = document.querySelectorAll('input[name="menu-items"]:checked');
+
+            if (!customerName || selectedCheckboxes.length === 0) {
+                alert('Please enter a customer name and select at least one item.');
+                return;
+            }
+
+            const allItems = [].concat(...Object.values(menu));
+            const selectedItems = Array.from(selectedCheckboxes).map(cb => {
+                return allItems.find(item => item.id === parseInt(cb.value));
+            });
+
+            const totalPrice = selectedItems.reduce((sum, item) => sum + item.price, 0);
+
+            const newOrder = {
+                orderId: `ORD${Date.now()}`, // Simple unique ID
+                customerName: customerName,
+                items: selectedItems,
+                deliveryTime: new Date(),
+                totalPrice: totalPrice,
+            };
+
+            orders.push(newOrder); // Add to the main orders array
+            renderOrdersTable(); // Re-render the table with the new order
+
+            // Clear the form
+            customerNameInput.value = '';
+            selectedCheckboxes.forEach(cb => cb.checked = false);
         });
     }
+
+    // --- 4. Initial render of the orders table on page load ---
+    renderOrdersTable();
 });


### PR DESCRIPTION
This commit introduces a new feature to the admin dashboard, allowing admins to place orders directly from the panel.

- Adds an "Order Now" form to `admin.html`.
- Implements the JavaScript logic in `admin.js` to dynamically populate the form with menu items, handle form submission, and add the new order to the "Current Orders" list without a page refresh.
- Adds CSS to style the new form elements.