### PR TITLE
fix: Serve frontend files from backend

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ const DB_PATH = path.join(__dirname, 'db.json');
 // Middleware
 app.use(cors());
 app.use(express.json());
+app.use(express.static(path.join(__dirname, '/'))); // Serve static files from root
 
 // Helper functions
 const readDB = () => JSON.parse(fs.readFileSync(DB_PATH, 'utf-8'));


### PR DESCRIPTION
This commit adds the express.static middleware to the Node.js server.

This allows the server to serve the static HTML, CSS, and JS files directly, so the entire application can be run by starting the server and navigating to http://localhost:3000. This resolves the "unable to connect" error the user was experiencing when opening the HTML files directly.